### PR TITLE
Fix code block styling in blog posts

### DIFF
--- a/src/pages/blog/[uid].tsx
+++ b/src/pages/blog/[uid].tsx
@@ -60,6 +60,31 @@ const styleContainer: CSSObject = {
   p: {
     margin: `${makeSpace('sm')} 0`,
   },
+  pre: {
+    backgroundColor: '#1e1e2e',
+    color: '#cdd6f4',
+    borderRadius: 8,
+    padding: makeSpace('sm'),
+    margin: `${makeSpace('md')} 0`,
+    overflowX: 'auto',
+    fontSize: '0.9em',
+    lineHeight: 1.6,
+    width: '100%',
+    boxSizing: 'border-box',
+  },
+  'pre code': {
+    fontFamily: "'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace",
+    backgroundColor: 'transparent',
+    padding: 0,
+    borderRadius: 0,
+  },
+  code: {
+    fontFamily: "'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace",
+    backgroundColor: 'rgba(128, 128, 128, 0.15)',
+    padding: '2px 6px',
+    borderRadius: 4,
+    fontSize: '0.9em',
+  },
 };
 
 // Each MDX file needs an explicit dynamic() call because webpack can't resolve


### PR DESCRIPTION
## Summary
- Add `pre` and `code` styles to blog post container to restore code block rendering
- The Meyer CSS reset strips default browser styles from `pre`/`code`, and the old Prismic RichText renderer was deleted during the MDX migration without replacement styles
- Fenced code blocks now render with dark background, monospace font, padding, and rounded corners
- Inline `code` gets a subtle background and monospace font

## Test plan
- [x] Visit /blog/coming-back-to-java/ and verify code blocks have shaded background and monospace font
- [x] Check all other blog posts with code blocks render correctly (only coming-back-to-java has code blocks; others verified to have none)
- [x] Verify inline code elements are styled (no blog posts currently use inline code, but styles are in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)