### PR TITLE
Remove broken contact link from about page

### DIFF
--- a/src/content/about.mdx
+++ b/src/content/about.mdx
@@ -34,4 +34,4 @@ I also enjoy playing tennis, hiking, biking, running, skiing, and snowboarding, 
 
 Oh...and my top 3 movies of all time are Forrest Gump, The Shawshank Redemption, and The Big Lebowski.
 
-That's all for now. If you are interested in connecting for any reason, please don't hesitate to [reach out](/)!
+That's all for now. If you are interested in connecting for any reason, please don't hesitate to reach out!


### PR DESCRIPTION
## Summary
- Remove dead link to non-existent contact form on the about page
- The contact page was removed in a previous cleanup but the link remained
- LinkedIn is available in the site footer for anyone wanting to connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)