### PR TITLE
Fix blog post layout overflow on all viewports

### DIFF
--- a/src/pages/blog/[uid].tsx
+++ b/src/pages/blog/[uid].tsx
@@ -8,14 +8,14 @@ import { makeSize, makeSpace, responsiveBreakpoints } from '../../utils/design';
 import { Layout } from '../../components/layout/Layout';
 
 const styleContainer: CSSObject = {
-  display: 'grid',
-  gridTemplateRows: 'min-content',
-  justifySelf: 'center',
-  justifyItems: 'center',
   margin: 'auto',
+  width: '100%',
   maxWidth: responsiveBreakpoints.tabletPortrait,
+  padding: `0 ${makeSpace('sm')}`,
+  boxSizing: 'border-box',
   // because shoemaker is a long word in iphone SE
   wordBreak: 'break-word',
+  overflow: 'hidden',
   h1: {
     fontSize: makeSize('h1'),
     margin: `${makeSpace('xl')} 0`,
@@ -84,6 +84,17 @@ const styleContainer: CSSObject = {
     padding: '2px 6px',
     borderRadius: 4,
     fontSize: '0.9em',
+  },
+  img: {
+    maxWidth: '100%',
+    height: 'auto',
+  },
+  iframe: {
+    maxWidth: '100%',
+  },
+  '.gist': {
+    maxWidth: '100%',
+    overflowX: 'auto',
   },
 };
 


### PR DESCRIPTION
## Summary
- Replace CSS grid layout with simple block layout for blog post container — the grid's `justifyItems: center` caused content to compute at intrinsic width (848px) regardless of `maxWidth` constraint, clipping text on all screen sizes
- Add padding, overflow constraints, and max-width rules for images, iframes, and gists to prevent overflow on mobile viewports

## Test plan
- [x] Verified all 4 blog posts render correctly at desktop width (1200px)
- [x] Verified all 4 blog posts render correctly at narrow width (616px)
- [x] Code blocks scroll horizontally within their container
- [x] Images, iframes, and gist embeds constrained to container width
- [x] Deployed to production and verified live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)