### PR TITLE
fix: enable HTTPS for apex domain (mattgilbride.com)

### DIFF
--- a/infrastructure/src/stack/index.ts
+++ b/infrastructure/src/stack/index.ts
@@ -1,4 +1,5 @@
 import { App, Stack, StackProps } from 'aws-cdk-lib';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 import { StaticSiteConstruct } from './static-site.construct';
 
@@ -8,7 +9,7 @@ class SiteStack extends Stack {
 
     const domainName = `mattgilbride.com`;
     const siteSubDomain = 'www';
-    const certificateArn = process.env.CERTIFICATE_ARN as string;
+    const certificateArn = StringParameter.fromStringParameterName(this, 'CertArnParam', 'certificateArn').stringValue;
 
     new StaticSiteConstruct(this, id, {
       domainName,

--- a/infrastructure/src/stack/static-site.construct.ts
+++ b/infrastructure/src/stack/static-site.construct.ts
@@ -47,20 +47,34 @@ export class StaticSiteConstruct extends Construct {
       `${id}-SiteDistribution`,
       {
         certificate,
-        domainNames: [siteDomain],
+        domainNames: [siteDomain, props.domainName],
         minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
         sslSupportMethod: cloudfront.SSLMethod.SNI,
         defaultBehavior: {
           origin: new origins.HttpOrigin(siteBucket.bucketWebsiteDomainName, {
             protocolPolicy: cloudfront.OriginProtocolPolicy.HTTP_ONLY,
           }),
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         },
       },
     );
 
-    // Route53 alias record for the CloudFront distribution
+    // Preserve the logical ID from the original CloudFrontWebDistribution deployment
+    // to avoid replacing the existing distribution (which would fail due to CNAME conflicts)
+    const cfnDistribution = distribution.node.defaultChild as cloudfront.CfnDistribution;
+    cfnDistribution.overrideLogicalId('homepageStaticSiteConstructhomepageSiteDistributionCFDistributionE401C628');
+
+    // Route53 alias records for the CloudFront distribution
     new route53.ARecord(this, 'SiteAliasRecord', {
       recordName: siteDomain,
+      target: route53.RecordTarget.fromAlias(
+        new targets.CloudFrontTarget(distribution),
+      ),
+      zone,
+    });
+
+    new route53.ARecord(this, 'ApexAliasRecord', {
+      recordName: props.domainName,
       target: route53.RecordTarget.fromAlias(
         new targets.CloudFrontTarget(distribution),
       ),


### PR DESCRIPTION
## Summary
- Read certificate ARN from SSM Parameter Store instead of `CERTIFICATE_ARN` env var, keeping it in sync with the `aws-infrastructure` stack
- Add `mattgilbride.com` (apex) to CloudFront distribution's domain aliases
- Add Route 53 A record for apex domain pointing to CloudFront (replaces old record that pointed directly to S3)
- Add explicit `redirect-to-https` viewer protocol policy

## Context
The apex domain `mattgilbride.com` was pointing directly to an S3 website endpoint, which doesn't support HTTPS. This caused certificate warnings in browsers. The companion PR in `aws-infrastructure` (already merged) added the apex domain as a SAN on the wildcard certificate.

## Test plan
- [x] `yarn synth` succeeds
- [x] `yarn deploy` succeeds
- [x] `mattgilbride.com` resolves to CloudFront IPs
- [x] HTTPS works on `mattgilbride.com` with valid certificate
- [x] `www.mattgilbride.com` continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)