### PR TITLE
refactor: remove CloudFront logical ID override

### DIFF
--- a/infrastructure/src/stack/static-site.construct.ts
+++ b/infrastructure/src/stack/static-site.construct.ts
@@ -59,11 +59,6 @@ export class StaticSiteConstruct extends Construct {
       },
     );
 
-    // Preserve the logical ID from the original CloudFrontWebDistribution deployment
-    // to avoid replacing the existing distribution (which would fail due to CNAME conflicts)
-    const cfnDistribution = distribution.node.defaultChild as cloudfront.CfnDistribution;
-    cfnDistribution.overrideLogicalId('homepageStaticSiteConstructhomepageSiteDistributionCFDistributionE401C628');
-
     // Route53 alias records for the CloudFront distribution
     new route53.ARecord(this, 'SiteAliasRecord', {
       recordName: siteDomain,


### PR DESCRIPTION
## Summary
- Remove the `overrideLogicalId` hack from the CloudFront distribution construct
- The stack was recreated from scratch with clean logical IDs, so this workaround for the `CloudFrontWebDistribution` -> `Distribution` migration is no longer needed
- Future deploys are now fully idempotent with no manual intervention required

## Test plan
- [x] Stack destroyed and recreated from scratch with `yarn deploy`
- [x] Site content redeployed to S3
- [x] HTTPS working on both `mattgilbride.com` and `www.mattgilbride.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)