### PR TITLE
Update years of experience on home page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -51,7 +51,7 @@ const Home = () => (
       </div>
       <div css={styleAbout}>
         <p>
-          I&apos;m a software engineer based in Philadelphia, with over a decade
+          I&apos;m a software engineer based in Philadelphia, with over 15 years
           of experience across a variety of industries and tech stacks. For the
           last four years, I&apos;ve been working on the Android Platform
           Security team at Google.


### PR DESCRIPTION
## Summary
- Update "over a decade" to "over 15 years" to accurately reflect experience since 2009

## Test plan
- [x] Text change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)