### PR TITLE
Register vibe-coding MDX in dynamic component map

### DIFF
--- a/src/pages/blog/[uid].tsx
+++ b/src/pages/blog/[uid].tsx
@@ -111,6 +111,9 @@ const mdxComponents: Record<string, React.ComponentType> = {
   'coming-back-to-java': dynamic(
     () => import('../../content/blog/coming-back-to-java.mdx'),
   ),
+  'vibe-coding': dynamic(
+    () => import('../../content/blog/vibe-coding.mdx'),
+  ),
 };
 
 interface BlogPostProps {


### PR DESCRIPTION
## Summary
- Add `vibe-coding` entry to the `mdxComponents` map in `[uid].tsx`
- Without this, the blog post page fails to render (React error #130 — undefined component)

## Test plan
- [x] `yarn build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)